### PR TITLE
Added Fight Track, Fixed round end & score, koth stage

### DIFF
--- a/Auds_Stats_Farmer/Auds_StatsFarmer_PTR_0.03.ow
+++ b/Auds_Stats_Farmer/Auds_StatsFarmer_PTR_0.03.ow
@@ -230,12 +230,12 @@ rule("Game in Progress: Remove HUD, Reset variables")
 		//If On Control don't log out the attacker and defender, just log teams
 		Skip If(Current Game Mode != Game Mode(Control), 2);
 		Log To Inspector(
-			Custom String("[ROUND_START] Started Round{0} on Map {1} with Teams {2}",
-				//We are not showing round number anymore
-				Null,
-
+			Custom String("[ROUND_START] Started Round on Map {0} Stage {1} with Teams {2}",
 				//Map
 				Current Map,
+
+				//Stage
+				Objective Index,
 
 				//Teams 
 				Custom String("[{0} , {1}]", 
@@ -285,12 +285,12 @@ rule("Game in Progress: Remove HUD, Reset variables")
 
 		//If on any other type that contains attacker and defender log out those teams
 		Log To Inspector(
-		Custom String("[ROUND_START] Started Round on Map {0} Stage {1} with Teams {2}",
+		Custom String("[ROUND_START] Started Round on Map {0} with Teams {2}",
 			//Map
 			Current Map,
 
-			//Stage
-			Objective Index,
+			//Not tracking stage outside of Koth
+			Null,
 
 			//Teams 
 			Custom String("[Attacker: {0} , Defender: {1}]", 


### PR DESCRIPTION
We now track with the variable "Fight" when a fight starts and ends based on instances of damage (fight starts when damage is done, ends if no damage done in the last 5 seconds);
Fixed an error that caused the logs for round end & end round score to be shown at the beginning of a game;
We now don't track round number at round start anymore, however we are tracking stage in koth at round start.