### PR TITLE
Round start and hero switch change

### DIFF
--- a/Auds_Stats_Farmer/Auds_StatsFarmer_PTR_0.03.ow
+++ b/Auds_Stats_Farmer/Auds_StatsFarmer_PTR_0.03.ow
@@ -240,7 +240,7 @@ rule("Game in Progress: Remove HUD, Reset variables")
 				//Teams 
 				Custom String("[{0} , {1}]", 
 					//Team One
-					Custom String("{0} : {1}",
+					Custom String("{0} : {1} (2)",
 						Global.AttackingTeam,
 
 						//Player List
@@ -252,12 +252,20 @@ rule("Game in Progress: Remove HUD, Reset variables")
 							Null 
 						),
 
+						//Hero List
+						Custom String("[{0}, {1}]",
+							Custom String("{0}, {1}, {2}", Hero of(Players In Slot(0, Team 1)), Hero of(Players In Slot(1, Team 1)), Hero of(Players In Slot(2, Team 1))),
 
-						Null
+							Custom String("{0}, {1}, {2}", Hero of(Players In Slot(3, Team 1)), Hero of(Players In Slot(4, Team 1)), Hero of(Players In Slot(5, Team 1))),
+
+							Null 
+						),
+
+
 					),
 
 					//Team Two
-					Custom String("{0} : {1}",
+					Custom String("{0} : {1} (2)",
 						Global.DefendingTeam,
 
 						//Player List
@@ -269,8 +277,14 @@ rule("Game in Progress: Remove HUD, Reset variables")
 							Null 
 						),
 
+						//Hero List
+						Custom String("[{0}, {1}]",
+							Custom String("{0}, {1}, {2}", Hero of(Players In Slot(0, Team 2)), Hero of(Players In Slot(1, Team 2)), Hero of(Players In Slot(2, Team 2))),
 
-						Null
+							Custom String("{0}, {1}, {2}", Hero of(Players In Slot(3, Team 2)), Hero of(Players In Slot(4, Team 2)), Hero of(Players In Slot(5, Team 2))),
+
+							Null 
+						),
 					),
 
 					Null
@@ -295,7 +309,7 @@ rule("Game in Progress: Remove HUD, Reset variables")
 			//Teams 
 			Custom String("[Attacker: {0} , Defender: {1}]", 
 				//Team One
-				Custom String("{0} : {1}",
+				Custom String("{0} : {1} (2)",
 					Global.AttackingTeam,
 
 					//Player List
@@ -307,10 +321,15 @@ rule("Game in Progress: Remove HUD, Reset variables")
 						Null 
 					),
 
-					Null
+					//Hero List
+					Custom String("[{0}, {1}]",
+						Custom String("{0}, {1}, {2}", Hero of(Players In Slot(0, Team Global.AttackingTeam)), Hero of(Players In Slot(1, Team Global.AttackingTeam)), Hero of(Players In Slot(2, Team Global.AttackingTeam))),
+						Custom String("{0}, {1}, {2}", Hero of(Players In Slot(3, Team Global.AttackingTeam)), Hero of(Players In Slot(4, Team Global.AttackingTeam)), Hero of(Players In Slot(5, Team Global.AttackingTeam))),
+						Null 
+					),
 				),
 				//Team Two
-				Custom String("{0} : {1}",
+				Custom String("{0} : {1} (2)",
 					Global.DefendingTeam,
 
 					//Player List
@@ -323,7 +342,12 @@ rule("Game in Progress: Remove HUD, Reset variables")
 					),
 
 
-					Null
+					//Hero List
+					Custom String("[{0}, {1}]",
+						Custom String("{0}, {1}, {2}", Hero of(Players In Slot(0, Team Global.DefendingTeam)), Hero of(Players In Slot(1, Team Global.DefendingTeam)), Hero of(Players In Slot(2, Team Global.DefendingTeam))),
+						Custom String("{0}, {1}, {2}", Hero of(Players In Slot(3, Team Global.DefendingTeam)), Hero of(Players In Slot(4, Team Global.DefendingTeam)), Hero of(Players In Slot(5, Team Global.DefendingTeam))),
+						Null 
+					),
 				),
 
 				Null
@@ -821,6 +845,8 @@ rule("Hero Swicthes"){
     }
 
     actions{
+		//skip log if game not in progress
+        skip if (is game in progress!=True, 1);
         //Log
         Log to Inspector(Custom String("[HERO_SWITCH] {0} switched to {1} (was {2})",
         		Custom String("{0} ({1})", Event Player, Team of(Event Player), Null),


### PR DESCRIPTION
We now output list of heroes played next to players when round starts;
We don't output hero switches before the round start