### PR TITLE
Teleportation Modification and Seita Score Modifications implementation.

### DIFF
--- a/SeitaComponents/ScoreModifications.ostw
+++ b/SeitaComponents/ScoreModifications.ostw
@@ -1,0 +1,81 @@
+/*
+*   Name:        ScoreModifications.ostw
+*   Author:      leguminote#5816
+*   Description: This file holds all the rules for Seita's 
+*                Score Modifications
+*/
+
+globalvar define GameModeVar = 0;
+
+globalvar define ScoreModifiedVar = 0;
+globalvar define FirstRoundDoneVar = false;
+
+/*
+*  @name        GameModeCheck:Escort
+*  @description Sets GameMode variable for Escort
+*/
+rule: "GameModeCheck:Escort"
+    if(CurrentGameMode() == GameMode.Escort) {
+        GameModeVar = 1;
+    }
+
+/*
+*  @name        GameModeCheck:Hybrid
+*  @description Sets GameMode variable for Hybrid
+*/
+rule: "GameModeCheck:Hybrid"
+    if(CurrentGameMode() == GameMode.Hybrid) {
+        GameModeVar = 1;
+    }
+
+/*
+*  @name        GameModeCheck:Assualt
+*  @description Sets GameMode variable for Assualt
+*/
+rule: "GameModeCheck:Assualt"
+    if(CurrentGameMode() == GameMode.Assault) {
+        GameModeVar = 2;
+    }
+
+/*
+*  @name        GameModeCheck:Control
+*  @description Sets GameMode variable for Control
+*/
+rule: "GameModeCheck:Control"
+    if(CurrentGameMode() == GameMode.Control) {
+        GameModeVar = 3;
+    }
+
+/*
+*  @name        FirstAttackDone
+*  @description Sets first round done when finished
+*/
+rule: "FirstAttackDone"
+    if(IsBetweenRounds())
+    if(IsTeamOnOffense(Team.Team2))
+    if(ScoreModifiedVar == 0) {
+        Wait(15, WaitBehavior.IgnoreCondition);
+        FirstRoundDoneVar = true;
+    }
+
+/*
+*  @name        SetTeamScore:Escort&Hybrid
+*  @description Set team score for escort and hybrid maps
+*/
+rule: "SetTeamScore:Escort&Hybrid"
+    if(FirstRoundDoneVar)
+    if(GameModeVar == 1) {
+        SetTeamScore(Team.Team2, 3);
+        ScoreModifiedVar = 1;
+    }
+
+/*
+*  @name        SetTeamScore:Assault
+*  @description Set team score for assault maps
+*/
+rule: "SetTeamScore:Assault"
+    if(FirstRoundDoneVar)
+    if(GameModeVar == 2) {
+        SetTeamScore(Team.Team2, 2);
+        ScoreModifiedVar = 1;
+    }

--- a/SeitaComponents/ScoreModifications.ostw
+++ b/SeitaComponents/ScoreModifications.ostw
@@ -7,8 +7,8 @@
 
 globalvar define GameModeVar = 0;
 
-globalvar define ScoreModifiedVar = 0;
-globalvar define FirstRoundDoneVar = false;
+globalvar define ScoreModified = 0;
+globalvar define FirstRoundDone = false;
 
 /*
 *  @name        GameModeCheck:Escort
@@ -53,9 +53,9 @@ rule: "GameModeCheck:Control"
 rule: "FirstAttackDone"
     if(IsBetweenRounds())
     if(IsTeamOnOffense(Team.Team2))
-    if(ScoreModifiedVar == 0) {
+    if(ScoreModified == 0) {
         Wait(15, WaitBehavior.IgnoreCondition);
-        FirstRoundDoneVar = true;
+        FirstRoundDone = true;
     }
 
 /*
@@ -63,10 +63,10 @@ rule: "FirstAttackDone"
 *  @description Set team score for escort and hybrid maps
 */
 rule: "SetTeamScore:Escort&Hybrid"
-    if(FirstRoundDoneVar)
+    if(FirstRoundDone)
     if(GameModeVar == 1) {
         SetTeamScore(Team.Team2, 3);
-        ScoreModifiedVar = 1;
+        ScoreModified = 1;
     }
 
 /*
@@ -74,8 +74,8 @@ rule: "SetTeamScore:Escort&Hybrid"
 *  @description Set team score for assault maps
 */
 rule: "SetTeamScore:Assault"
-    if(FirstRoundDoneVar)
+    if(FirstRoundDone)
     if(GameModeVar == 2) {
         SetTeamScore(Team.Team2, 2);
-        ScoreModifiedVar = 1;
+        ScoreModified = 1;
     }

--- a/SeitaComponents/SetupRules.ostw
+++ b/SeitaComponents/SetupRules.ostw
@@ -4,9 +4,10 @@
 */
 
 
-import "SetupFunctions.ostw"; //For functions dedicated to the setup of seita lobby
-import "Controls.ostw";       //For controls Seita made to make scrimming easier
-import "Teleportation.ostw";  //For Seita defender teleportation
+import "SetupFunctions.ostw";     //For functions dedicated to the setup of seita lobby
+import "Controls.ostw";           //For controls Seita made to make scrimming easier
+import "Teleportation.ostw";      //For Seita defender teleportation
+import "ScoreModifications.ostw"; //For Seita score modifications
 
 //Setup ready-up system
 globalvar define Team1Ready = false;

--- a/SeitaComponents/Teleportation.ostw
+++ b/SeitaComponents/Teleportation.ostw
@@ -55,11 +55,11 @@ rule: "TeleportPlayer" Event.OngoingPlayer
     //Checks
     if(IsInSetup())                                 // If in setup
     if(IsTeamOnDefense(TeamOf(EventPlayer())))      // If the player is on defense
+    if(IsInSpawnRoom(EventPlayer()))                // If the player is in spawn
     if(HasSpawned(EventPlayer()))                   // If they spawned
-    if(IsButtonHeld(EventPlayer(), Button.Melee))  // If they're holding melee
+    if(IsButtonHeld(EventPlayer(), Button.Melee))   // If they're holding melee
     if(IsAlive(EventPlayer()))                      // If they're alive
     if(HeroOf(EventPlayer()))                       // If they've selected a hero... I think
-    if(MatchTime() >= 1)                            // If match is actually on
     //Teleport to location based on map (if map has teleport location)
     if(ArrayContains(MapsList,CurrentMap())) {
         Teleport(EventPlayer(), LocationsList[IndexOfArrayValue(MapsList, CurrentMap())]);

--- a/SeitaComponents/Teleportation.ostw
+++ b/SeitaComponents/Teleportation.ostw
@@ -1,9 +1,11 @@
 /*
-*   Name:        Controls.ostw
+*   Name:        Teleportation.ostw
 *   Author:      leguminote#5816
 *   Description: This file holds all the rules for Seita's QoL Teleportation
 */
 
+//List of maps to be used for teleportation
+//Map list has same order as teleportation list
 globalvar define maps_list! = [
     Map.Blizzard_World,
     Map.Eichenwalde,
@@ -23,6 +25,8 @@ globalvar define maps_list! = [
     Map.Watchpoint_Gibraltar
 ];
 
+//List of Vectors to be used for map teleportation
+//Locations list has same order as map list
 globalvar define locations_list! = [
     Vector(-8.171, 3.824, 65.861),
     Vector(13.226, 12.981, -83.655),
@@ -56,6 +60,7 @@ rule: "TeleportPlayer" Event.OngoingPlayer
     if(IsAlive(EventPlayer()))                      // If they're alive
     if(HeroOf(EventPlayer()))                       // If they've selected a hero... I think
     if(MatchTime() >= 1)                            // If match is actually on
+    //Teleport to location based on map (if map has teleport location)
     if(ArrayContains(maps_list,CurrentMap())) {
         Teleport(EventPlayer(), locations_list[IndexOfArrayValue(maps_list, CurrentMap())]);
     }

--- a/SeitaComponents/Teleportation.ostw
+++ b/SeitaComponents/Teleportation.ostw
@@ -6,7 +6,7 @@
 
 //List of maps to be used for teleportation
 //Map list has same order as teleportation list
-globalvar define maps_list! = [
+globalvar define MapsList! = [
     Map.Blizzard_World,
     Map.Eichenwalde,
     Map.Hollywood,
@@ -27,7 +27,7 @@ globalvar define maps_list! = [
 
 //List of Vectors to be used for map teleportation
 //Locations list has same order as map list
-globalvar define locations_list! = [
+globalvar define LocationsList! = [
     Vector(-8.171, 3.824, 65.861),
     Vector(13.226, 12.981, -83.655),
     Vector(-19.248, 8.007, -9.802),
@@ -61,7 +61,7 @@ rule: "TeleportPlayer" Event.OngoingPlayer
     if(HeroOf(EventPlayer()))                       // If they've selected a hero... I think
     if(MatchTime() >= 1)                            // If match is actually on
     //Teleport to location based on map (if map has teleport location)
-    if(ArrayContains(maps_list,CurrentMap())) {
-        Teleport(EventPlayer(), locations_list[IndexOfArrayValue(maps_list, CurrentMap())]);
+    if(ArrayContains(MapsList,CurrentMap())) {
+        Teleport(EventPlayer(), LocationsList[IndexOfArrayValue(MapsList, CurrentMap())]);
     }
     


### PR DESCRIPTION
Added / Modified comments in teleportation.

Added InSpawn condition to teleport to match original seita rule.
Removed accidental time >= 1 condition not in original seita rule.

Implemented Seita Score Modifications needed to change scores so game doesn't end early (scrim rules).
Note: GameMode variable replaced with GameModeVar variable, because OSTW uses GameMode() to represent Game Mode().
Included rules to set GameModeVar in ScoreModifications file. Escort/Hybrid =1, Assault =2, Control =3.