### PR TITLE
OSTW Rewrite Round / Objective Logs

### DIFF
--- a/ScrimCode.ostw
+++ b/ScrimCode.ostw
@@ -9,6 +9,10 @@ import "./ScrimSettings.json";   //Lobby Settings
 //Seita's Components
 import "./SeitaComponents/SetupRules.ostw";
 
+//Stats
+import "./Stats/RoundLogs.ostw";
+import "./Stats/ObjectiveLogs.ostw";
+
 rule: "Aud hates life" {
     LogToInspector("Fucking hell");
 

--- a/Stats/HelperFunctions/InfoUtils.ostw
+++ b/Stats/HelperFunctions/InfoUtils.ostw
@@ -1,0 +1,45 @@
+/*
+*   Name:        InfoUtils.ostw
+*   Author:      leguminote#5816
+*   Description: This file holds the code to get commonly needed information
+*/
+
+/*
+*  @name        AttackingTeam
+*  @description Get attacking team
+*  Note:        Requires non control map
+*  <Macro>
+*/
+define AttackingTeam():
+    IsTeamOnOffense(Team.Team1) ? Team.Team1 : Team.Team2;
+
+/*
+*  @name        DefendingTeam
+*  @description Get defending team
+*  Note:        Requires non control map
+*  <Macro>
+*/
+define DefendingTeam():
+    IsTeamOnDefense(Team.Team1) ? Team.Team1 : Team.Team2;
+
+/*
+*  @name        ControlWinningTeam
+*  @description Get control winning team
+*  Note:        Requires control map
+*  <Macro>
+*/
+define ControlWinningTeam():
+    ControlModeScoringPercentage(Team.Team1) > ControlModeScoringPercentage(Team.Team2) ?
+        Team.Team1 : 
+        Team.Team2;
+
+/*
+*  @name        ControlLosingTeam
+*  @description Get control lsoing team
+*  Note:        Requires control map
+*  <Macro>
+*/
+define ControlLosingTeam():
+    ControlModeScoringPercentage(Team.Team1) > ControlModeScoringPercentage(Team.Team2) ?
+        Team.Team2 : 
+        Team.Team1;

--- a/Stats/HelperFunctions/StringUtils.ostw
+++ b/Stats/HelperFunctions/StringUtils.ostw
@@ -1,0 +1,27 @@
+/*
+*   Name:        StringUtils.ostw
+*   Author:      leguminote#5816
+*   Description: This file holds the code to create commonly used strings for logging
+*/
+
+/*
+*  @name        TeamString
+*  @description Gets string with [Team] : <[player]s> <[hero]es>
+*  <Macro>
+*/
+define TeamString(Team team):
+    <"[<0>] : [<1>], [<2>], [<3>], [<4>], [<5>], [<6>] [<7>], [<8>], [<9>], [<10>], [<11>], [<12>]",
+        team,
+        PlayersInSlot(0, team),
+        PlayersInSlot(1, team),
+        PlayersInSlot(2, team),
+        PlayersInSlot(3, team),
+        PlayersInSlot(4, team),
+        PlayersInSlot(5, team),
+        HeroOf(PlayersInSlot(0, team)),
+        HeroOf(PlayersInSlot(1, team)),
+        HeroOf(PlayersInSlot(2, team)),
+        HeroOf(PlayersInSlot(3, team)),
+        HeroOf(PlayersInSlot(4, team)),
+        HeroOf(PlayersInSlot(5, team))
+    >;

--- a/Stats/ObjectiveLogs.ostw
+++ b/Stats/ObjectiveLogs.ostw
@@ -1,0 +1,122 @@
+/*
+*   Name:        ObjectiveLogs.ostw
+*   Author:      leguminote#5816
+*   Description: This file holds the code to log objective info
+*/
+
+import "./HelperFunctions/StringUtils.ostw";
+import "./HelperFunctions/InfoUtils.ostw";
+
+globalvar define CaptureProgress = 0;
+globalvar define WhoControlsPoint = Team.All;
+globalvar define NextTick = 0;
+
+/*
+*  @name        ControlPointFlip
+*  @description Log control point flip and update who controls point
+*/
+rule: "ControlPointFlip"
+    if(IsGameInProgress())
+    if(CurrentGameMode() == GameMode.Control)
+    if(Not(IsControlModePointLocked()))
+    if(WhoControlsPoint != ControlModeScoringTeam())
+    {
+        LogToInspector(<"[POINT_FLIP] [<0>] has taken the point, currently: [<1>]% (vs:[<2>]%)",
+            ControlModeScoringTeam(),
+            RoundToInteger(ControlModeScoringPercentage(ControlModeScoringTeam()), Rounding.Down),
+            RoundToInteger(ControlModeScoringPercentage(OppositeTeamOf(ControlModeScoringTeam())))
+        >);
+        WhoControlsPoint = ControlModeScoringTeam();
+    }
+
+/*
+*  @name        ControlUpdatePercentageIncrease
+*  @description Log control update percentage increase
+*/
+rule: "ControlUpdatePercentageIncrease"
+    if(CurrentGameMode() == GameMode.Control)
+    if(IsGameInProgress())
+    if(WhoControlsPoint != Team.All)
+    if(RoundToInteger(ControlModeScoringPercentage(ControlModeScoringTeam()), Rounding.Down) % 10 == 0)
+    {
+        LogToInspector(<"[POINT_UPDATE] [<0>] captured [<1>]%",
+            ControlModeScoringTeam(), 
+            RoundToInteger(ControlModeScoringPercentage(ControlModeScoringTeam()), Rounding.Down)
+        >);
+        CaptureProgress = ControlModeScoringPercentage(ControlModeScoringTeam());
+    }
+
+/*
+*  @name        HybridTickGain
+*  @description Log hybrid tick gain
+*/
+rule: "HybridTickGain"
+    if(IsGameInProgress())
+    if(CurrentGameMode() == GameMode.Hybrid)
+    if(PointCapturePercentage() >= NextTick * 100/3 && PointCapturePercentage() < NextTick * 100/3 + 1)
+    {
+        if(NextTick > 0) {
+            LogToInspector(<"[EARNED_TICK] [<0>] captured [<1>]%", AttackingTeam(), RoundToInteger(PointCapturePercentage(), Rounding.Down)>);
+        }
+        NextTick++;
+    }
+
+/*
+*  @name        HybridPointCaptured
+*  @description Log hybrid point capped
+*/
+rule: "HybridPointCaptured"
+    if(IsGameInProgress())
+    if(CurrentGameMode() == GameMode.Hybrid)
+    if(IsObjectiveComplete(CaptureProgress))
+    {
+        LogToInspector(<"[WON_POINT] [<0>] CAPTURED POINT [<1>]", AttackingTeam(), CaptureProgress + 1>);
+        CaptureProgress = ObjectiveIndex();
+        NextTick = 0;
+    }
+
+/*
+*  @name        AssaultTickGain
+*  @description Log assualt tick gain
+*/
+rule: "AssaultTickGain"
+    if(IsGameInProgress())
+    if(CurrentGameMode() == GameMode.Assault)
+    if(PointCapturePercentage() >= NextTick * 100/3 && PointCapturePercentage() < NextTick * 100/3 + 1)
+    {
+        if(NextTick > 0) {
+            LogToInspector(<"[EARNED_TICK] [<0>] captured [<1>]% of Point [<2>]",
+                AttackingTeam(),
+                RoundToInteger(PointCapturePercentage(), Rounding.Down),
+                ObjectiveIndex() + 1
+            >);
+        }
+        NextTick++;
+    }
+
+/*
+*  @name        AssaultPointCaptured
+*  @description Log assault point capped
+*/
+rule: "AssaultPointCaptured"
+    if(IsGameInProgress())
+    if(CurrentGameMode() == GameMode.Assault)
+    if(IsObjectiveComplete(CaptureProgress))
+    {
+        LogToInspector(<"[WON_POINT] [<0>] CAPTURED POINT [<1>]", AttackingTeam(), CaptureProgress + 1>);
+        CaptureProgress = ObjectiveIndex();
+        NextTick = 0;
+    }
+
+/*
+*  @name        EscortUpdate
+*  @description Log Escort checkpoints
+*/
+rule: "EscortUpdate"
+    if(IsGameInProgress())
+    if(CurrentGameMode() == GameMode.Escort)
+    if(IsObjectiveComplete(CaptureProgress))
+    {
+        LogToInspector(<"[WON_POINT] [<0>] CAPTURED POINT [<1>]", AttackingTeam(), CaptureProgress + 1>);
+        CaptureProgress = ObjectiveIndex();
+    }

--- a/Stats/RoundLogs.ostw
+++ b/Stats/RoundLogs.ostw
@@ -1,0 +1,72 @@
+/*
+*   Name:        RoundLogs.ostw
+*   Author:      leguminote#5816
+*   Description: This file holds the code to log round information
+*/
+
+import "./HelperFunctions/StringUtils.ostw";
+import "./HelperFunctions/InfoUtils.ostw";
+
+/*
+*  @name        LogRoundStart
+*  @description Inital logs for round start
+*/
+rule: "LogRoundStart"
+    if(IsGameInProgress())
+    {
+        LogToInspector("[VERSION] Running on version [0.0.4] [Scrim] version");
+        if (CurrentGameMode() != GameMode.Control)
+        {
+            LogToInspector(
+                <"[ROUND_START_ALL] Started Round on Map [<0>] with Teams Attacker: <1> , Defender: <2>",
+                    CurrentMap(),
+                    TeamString(AttackingTeam()),
+                    TeamString(DefendingTeam())
+                >);
+        } else {
+            LogToInspector(
+                <"[ROUND_START_CONTROL] Started Round on Map [<0>] Stage [<1>] with Teams <2> , <3>",
+                    CurrentMap(),
+                    ObjectiveIndex(),
+                    TeamString(Team.Team1),
+                    TeamString(Team.Team2)
+                >);
+        }
+    }
+
+/*
+*  @name        LogRoundEndControl
+*  @description Inital logs for round end control
+*/
+rule: "LogRoundEndControl"
+    if(Not(IsGameInProgress()))
+    if(CurrentGameMode() == GameMode.Control)
+    {
+        if(TotalTimeElapsed() > 5) {
+            LogToInspector(<"[ROUND_END_SCORE] Team [<0>] Won with a score of [<1>] vs Team [<2>] Lost with a score of [<3>]",
+                ControlWinningTeam(),
+                ControlModeScoringPercentage(ControlWinningTeam()),
+                ControlLosingTeam(),
+                ControlModeScoringPercentage(ControlLosingTeam())
+            >);
+            LogToInspector("[ROUND_END]");
+        }        
+    }
+
+/*
+*  @name        LogRoundEndControl
+*  @description Inital logs for round end control
+*/
+rule: "LogRoundEndNonControl"
+    if(Not(IsGameInProgress()))
+    if(CurrentGameMode() != GameMode.Control)
+    {
+        if(TotalTimeElapsed() > 5)
+        {
+            LogToInspector(<"[SCORE_ALL] [<0>] SCORED [<1>]",
+                AttackingTeam(),
+                TeamScore(AttackingTeam())
+            >);
+            LogToInspector("[ROUND_END]");
+        }
+    }


### PR DESCRIPTION
This pull request includes code to duplicate the logs for round start / end and objective status / updates. 

Also fixes bug related to earning more than a tick and letting it decay back to a tick causing duplicated tick logs.

Includes some utility function files that can be added to when needed.

Uses same file structure as Pull Request #19 but doesn't include that code as that is not part of the rewrite (it is an additional feature / code to allow additional features)